### PR TITLE
Add list of custom derives

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -36,7 +36,7 @@ pub struct Attrs {
     display: bool,
 
     #[darling(default)]
-    custom_derives: Option<PathList>,
+    derive: Option<PathList>,
 }
 
 fn pointy_bits(ty: &syn::Type) -> Punctuated<GenericArgument, Token![,]> {
@@ -226,7 +226,7 @@ fn do_newtype(mut attrs: Attrs, item: Item) -> Result<TokenStream, syn::Error> {
         None
     };
 
-    let derives = if let Some(custom_derives) = attrs.custom_derives {
+    let derives = if let Some(custom_derives) = attrs.derive {
         let paths = custom_derives.deref().clone();
         quote! { #[derive( #(#paths),*)]}
     } else {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -29,3 +29,25 @@ fn ahhh3() {
     assert_eq!(wow.deref(), "wew lad");
     assert_eq!(wow.into_inner(), "wew lad");
 }
+
+#[test]
+fn ahhh4() {
+    struct DeriveNothing {}
+
+    #[newtype(custom_derives())]
+    type Hello = DeriveNothing;
+
+    assert!(true);// if it builds it works
+}
+
+#[test]
+fn ahhh5() {
+    #[derive(Debug)]
+    struct JustDebug(u32);
+
+    #[newtype(custom_derives(Debug))]
+    type Hello = JustDebug;
+
+    assert_eq!("JustDebug(42)", &format!("{:?}", JustDebug(42)));
+    assert_eq!("Hello(JustDebug(42))", &format!("{:?}", Hello(JustDebug(42))));
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -42,12 +42,21 @@ fn ahhh4() {
 
 #[test]
 fn ahhh5() {
-    #[derive(Debug)]
-    struct JustDebug(u32);
+    #[derive(Debug,Copy,Clone)]
+    struct DebugCopyClone(u32);
 
-    #[newtype(custom_derives(Debug))]
-    type Hello = JustDebug;
+    #[newtype(custom_derives(Debug,Copy,Clone))]
+    type Hello = DebugCopyClone;
 
-    assert_eq!("JustDebug(42)", &format!("{:?}", JustDebug(42)));
-    assert_eq!("Hello(JustDebug(42))", &format!("{:?}", Hello(JustDebug(42))));
+    assert_eq!("DebugCopyClone(42)", &format!("{:?}", DebugCopyClone(42)));
+
+    let hello = Hello(DebugCopyClone(42));
+    assert_eq!("Hello(DebugCopyClone(42))", &format!("{:?}", hello));
+
+    let goodbye = hello;
+    assert_eq!("Hello(DebugCopyClone(42))", &format!("{:?}", hello));
+    assert_eq!("Hello(DebugCopyClone(42))", &format!("{:?}", goodbye));
+
+
+
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -34,7 +34,7 @@ fn ahhh3() {
 fn ahhh4() {
     struct DeriveNothing {}
 
-    #[newtype(custom_derives())]
+    #[newtype(derive())]
     type Hello = DeriveNothing;
 
     assert!(true);// if it builds it works
@@ -45,7 +45,7 @@ fn ahhh5() {
     #[derive(Debug,Copy,Clone)]
     struct DebugCopyClone(u32);
 
-    #[newtype(custom_derives(Debug,Copy,Clone))]
+    #[newtype(derive(Debug,Copy,Clone))]
     type Hello = DebugCopyClone;
 
     assert_eq!("DebugCopyClone(42)", &format!("{:?}", DebugCopyClone(42)));


### PR DESCRIPTION
Closes #1

This PR is aimed at adding an optional list of `custom_derive` traits. 

```rust
    #[derive(Debug,Copy,Clone)]
    struct DebugCopyClone(u32); // does not implement PartialEq, PartialOrd

    #[newtype(custom_derives(Debug,Copy,Clone))]
    type Hello = DebugCopyClone;
```

